### PR TITLE
Add options to highlightAreaPlot

### DIFF
--- a/code/+aratools/+projectAtlas/createBoundaries.m
+++ b/code/+aratools/+projectAtlas/createBoundaries.m
@@ -28,7 +28,7 @@ end
 
 warning('off','MATLAB:table:RowsAddedNewVars')
 out.structureList.areaBoundaries(:)={};
-
+out.structureList.areaHemisphere(:)={};
 for ind = 1:height(projectedAtlasStuct.structureList)
     R = projectedAtlasStuct.projectedAtlas==projectedAtlasStuct.structureList.id(ind);
 
@@ -44,6 +44,33 @@ for ind = 1:height(projectedAtlasStuct.structureList)
 
     %Store the boundaries in the table
     projectedAtlasStuct.structureList.areaBoundaries{ind}=B;
+    
+    % Find on which hemisphere each of the boundary is
+    if projectedAtlasStuct.dim == 2
+        % it is a sagital view. Hemisphere doesn't make sense
+        whichHem = nan(size(B));
+    elseif projectedAtlasStuct.dim == 1
+        % it is a dorsal view. 
+        whichHem = zeros(size(B));
+        midLine = size(projectedAtlasStuct.projectedAtlas,2)/2;
+        for iB =1:numel(B)
+            b = B{iB};
+            inLeftHem = double(any(b(:,2)<=midLine));
+            inRightHem = double(any(b(:,2)>=midLine));
+            whichHem(iB) = inLeftHem + 2 * inRightHem;
+        end
+    elseif  projectedAtlasStuct.dim == 3
+        %if is a coronal view
+        whichHem = zeros(size(B));
+        midLine = size(projectedAtlasStuct.projectedAtlas,2)/2;
+        for iB =1:numel(B)
+            b = B{iB};
+            inLeftHem = double(any(b(:,2)<=midLine));
+            inRightHem = double(any(b(:,2)>=midLine));
+            whichHem(iB) = inLeftHem + 2 * inRightHem;
+        end
+    end
+    projectedAtlasStuct.structureList.areaHemisphere{ind} = whichHem;
 end
 
 warning('on','MATLAB:table:RowsAddedNewVars')

--- a/code/+aratools/+projectAtlas/highlightAreaPlot.m
+++ b/code/+aratools/+projectAtlas/highlightAreaPlot.m
@@ -1,4 +1,4 @@
-function varargout=highlightAreaPlot(projectionStructure,highlightList)
+function varargout=highlightAreaPlot(projectionStructure, highlightList, whichHem)
     %% Plot projected Allen Atlas with named brain area highlighted
     %
     % function H=aratools.projectAtlas.highlightAreaPlot(projectionStructure,highlightList)
@@ -15,6 +15,8 @@ function varargout=highlightAreaPlot(projectionStructure,highlightList)
     %   highlightList - cell array of strings of area names. If missing then nothing is highlighted
     %                   and no error is generated.
     %
+    % Inputs [optional]
+    %   whichHem - 1 for left, 2 for right, 3 for both. Can be combined
     %
     % Outputs
     % H - optionally a structure containing the handles for the plotted objects and other associated
@@ -41,7 +43,9 @@ function varargout=highlightAreaPlot(projectionStructure,highlightList)
         help mfilename
         return
     end
-
+    if ~exist('whichHem', 'var')
+        whichHem = [];
+    end
 
     %If the user supplied a list of areas to highlight, then we go through the list, find the 
     %areas and set up the colors
@@ -50,22 +54,22 @@ function varargout=highlightAreaPlot(projectionStructure,highlightList)
             fprintf('** highlightList should be a cell array\n')
             return
         end
-
-        hlitedInds = []; %List of indexes in the structure list that we will highlight
+        if length(highlightList)==1
+            hlightCols=[1,0,0];
+        else
+            hlightCols = parula(length(highlightList));
+        end
+        hlitedInds = nan(1, length(highlightList)); %List of indexes in the structure list that we will highlight
         for ii=1:length(highlightList)
             IND = strmatch(highlightList{ii}, projectionStructure.structureList.name);
             if isempty(IND)
                 fprintf('Failed to find brain area for name %s. Skipping\n', highlightList{ii});
                 continue
             end
-            hlitedInds=[hlitedInds;IND];
+            hlitedInds(ii)=IND;
         end
 
-        if length(hlitedInds)==1
-            hlightCols=[1,0,0];
-        else
-            hlightCols = parula(length(hlitedInds));
-        end
+     
 
     end
 
@@ -79,14 +83,19 @@ function varargout=highlightAreaPlot(projectionStructure,highlightList)
     hold on
 
     nB=1;
-    nP=1;
     H.plottedNames={}; %The areas plotted in order
     for ii = 1:height(projectionStructure.structureList);
         B = projectionStructure.structureList.areaBoundaries{ii}; %Collect the border data for this area
 
         if any(hlitedInds==ii)
+            if ~isempty(whichHem)
+                hemInfo = projectionStructure.structureList.areaHemisphere{ii};
+                okHem = ismember(hemInfo, whichHem);
+                makeLineBoundary(B(~okHem))
+                B = B(okHem);
+            end
             H.plottedNames{end+1}=projectionStructure.structureList.name{ii};
-            makeArea(B)
+            makeArea(B, find(hlitedInds==ii))
         else
             makeLineBoundary(B)
         end
@@ -111,12 +120,11 @@ function varargout=highlightAreaPlot(projectionStructure,highlightList)
 
     end
 
-    function makeArea(B)
+    function makeArea(B, colorIndex)
        for k = 1:length(B)
          thisBoundary = B{k};
-         H.hLight(nP,k)=patch(thisBoundary(:,2), thisBoundary(:,1),hlightCols(nP,:));
+         H.hLight(colorIndex,k)=patch(thisBoundary(:,2), thisBoundary(:,1),hlightCols(colorIndex,:));
        end
-       nP=nP+1;
     end
 
 end


### PR DESCRIPTION
Now the color of the area depends on the number of areas are in the
input list, not on how many are in the current image (so that the
colour does not change if you plot different projections)

Add the option to highlight only on hemisphere (or area spanning
both)

Add in createBoundaries the info about the hemisphere of each
independant boundary.